### PR TITLE
release: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project are documented here. Pythonlings follows
 Semantic Versioning.
 
+## [0.4.1] - 2026-06-21
+
+### Added
+
+- First-launch welcome screen that explains the edit → save → advance loop and
+  the key shortcuts, shown once on a genuine first run.
+- The TUI progress bar now shows overall curriculum progress alongside the
+  current topic's progress.
+- A celebration screen when every exercise in the curriculum is complete.
+
+### Fixed
+
+- Finishing a single topic no longer shows the whole-curriculum "All exercises
+  complete" header; it now shows a "Topic complete" header.
+
 ## [0.4.0] - 2026-06-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pythonlings"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python learnings, Rustlings-style, in a terminal TUI."
 readme = "Readme.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch release bundling the TUI features merged since v0.4.0.

Versioned **0.4.1 (patch)** rather than 0.5.0 deliberately: these are additive UI polish (welcome modal, an extra progress line, a celebration screen), not a milestone on the scale of the rename (0.3.0) or zero-config first-run (0.4.0) that earned those minors.

## Included
**Added** (from #31)
- First-launch welcome screen explaining the loop.
- Overall curriculum progress in the TUI alongside per-topic.
- Completion celebration at 100%.

**Fixed** (from #32)
- Topic completion no longer shows the whole-curriculum "All exercises complete" header.

Bumps `pyproject.toml` to 0.4.1 (the only version source — `--version` reads package metadata) and adds the CHANGELOG entry. Built wheel/sdist verified locally; `pythonlings --version` → `0.4.1`. Suite: 147 passing on 3.9 + 3.13.

Merging this, then tagging `v0.4.1` + creating the GitHub release triggers the trusted-publishing workflow to PyPI.