### PR TITLE
feat(docs): new terminal-window logo + refined favicon

### DIFF
--- a/docs-site/assets/favicon.svg
+++ b/docs-site/assets/favicon.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <rect width="64" height="64" rx="12" fill="#3776AB"/>
-  <path d="M16 22l9 10-9 10" fill="none" stroke="#FFD43B" stroke-width="5"
-    stroke-linecap="round" stroke-linejoin="round"/>
-  <rect x="30" y="40" width="18" height="5" rx="2.5" fill="#FFD43B"/>
+  <path d="M18 18l13 14-13 14" fill="none" stroke="#4B8BBE" stroke-width="7"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="34" y="39" width="16" height="6" rx="3" fill="#FFD43B"/>
 </svg>

--- a/docs-site/assets/logo.svg
+++ b/docs-site/assets/logo.svg
@@ -1,5 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <path d="M16 22l9 10-9 10" fill="none" stroke="#FFD43B" stroke-width="5"
-    stroke-linecap="round" stroke-linejoin="round"/>
-  <rect x="30" y="40" width="18" height="5" rx="2.5" fill="#FFD43B"/>
+  <rect x="4" y="9" width="56" height="46" rx="11" fill="#23233B"/>
+  <circle cx="15" cy="19" r="2.6" fill="#FF5F56"/>
+  <circle cx="23" cy="19" r="2.6" fill="#FFBD2E"/>
+  <circle cx="31" cy="19" r="2.6" fill="#27C93F"/>
+  <path d="M17 31l8.5 8.5-8.5 8.5" fill="none" stroke="#FFD43B" stroke-width="4.6"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="31" y="43.5" width="15" height="4.6" rx="2.3" fill="#4B8BBE"/>
 </svg>


### PR DESCRIPTION
Refreshes the site branding from the minimal single-color `>_` mark to a two-tone Python palette (`#4B8BBE` blue + `#FFD43B` yellow).

- **Logo** (`docs-site/assets/logo.svg`) — a rounded dark terminal window with traffic-light dots and a yellow prompt + blue cursor inside. Richer header mark; also feeds the auto-generated OG/social cards.
- **Favicon** (`docs-site/assets/favicon.svg`) — a bolder standalone `>_` prompt that stays legible at 16px (the window mark would be too busy that small).

Chosen as a combo (window logo + simple-prompt favicon) so the header is rich and the tab icon is legible.

No config change: `mkdocs.yml` already points `theme.logo`/`theme.favicon` at these paths, and Material's social plugin regenerates cards from the logo in CI. Both SVGs validated as well-formed XML.