### PR TITLE
fix: Add pylings to the Rustlings third-party exercises list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here. Pythonlings follows
 Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- Listed in the Rustlings third-party exercises community list.
+
 ## [0.4.1] - 2026-06-21
 
 ### Added


### PR DESCRIPTION
Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Unreleased changelog entry noting inclusion in the Rustlings third-party exercises community list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->