### PR TITLE
docs: document contributor branch policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
+<!-- AGENTS.md -->
 # AGENTS.md
 
 ## Scope
@@ -46,10 +47,15 @@ Record the exact commands and their results in the pull request description.
 
 ## Branch and Merge Policy
 
-- Branch from the current `main` and target pull requests to `main`.
-- Use `dev` only when an explicitly approved release plan reactivates it.
+- Follow `CONTRIBUTING.md` for branch naming, pull request content, and the
+  contributor workflow.
+- Branch from the current `dev` using `feature/<name>` or `fix/<name>`, and
+  target pull requests to `dev`.
 - Keep pull requests in draft until local validation is complete and recorded.
-- Merge with a merge commit only after CI passes and review feedback is resolved.
+- Squash-merge feature and fix pull requests into `dev` only after CI passes and
+  review feedback is resolved.
+- Promote a verified `dev` branch to `main` with a merge commit. Do not squash
+  the `dev` to `main` release promotion.
 - Never merge or enable auto-merge without explicit maintainer approval.
 
 ## Compatibility and Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- CONTRIBUTING.md -->
 # Contributing
 
 Pythonlings is actively developed and **open to contributors** — beginners welcome.
@@ -39,8 +40,21 @@ reference solution** (`tests/integration/test_solution_verify.py` enforces this)
 
 ## Pull Requests
 
-- Use focused branches named `feature/<name>` or `fix/<name>`.
+- Create focused branches from the current `dev` branch, named
+  `feature/<name>` or `fix/<name>`.
+- Open pull requests against `dev`. Feature and fix pull requests are
+  squash-merged after CI passes and review feedback is resolved.
 - Reference the issue you're closing (`Closes #NN`).
 - Include a short description, test output (`python -m pytest -q`), and
   screenshots/GIFs for TUI changes.
 - Keep PRs scoped to one issue where possible.
+
+## Release Flow
+
+```text
+feature/<name> or fix/<name> -> dev -> main -> vMAJOR.MINOR.PATCH
+```
+
+Maintainers promote a verified `dev` branch to `main` with a merge commit, not
+a squash merge. The release tag is created from the exact promoted commit on
+`main`; see [RELEASE.md](RELEASE.md) for the release checklist.


### PR DESCRIPTION
## Summary

- make `dev` the integration target for feature and fix pull requests
- document squash merges into `dev` and merge-commit promotions to `main`
- link the contributor guide and release checklist as the sources of truth

## Why

The contributor workflow and repository policy need to describe the release branch topology consistently before the v0.4.2 integration work begins.

## Impact

Contributors now have one clear branch, pull request, and release flow. This is documentation-only and does not change runtime behavior.

## Validation

- `python -m pytest -q` -> `151 passed`
- `pythonlings --root tests/fixtures/passing_curriculum verify` -> `passing1`, `passing2`
- `git diff --check` -> passed