### PR TITLE
chore: prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
+<!-- CHANGELOG.md -->
 # Changelog
 
 All notable changes to this project are documented here. Pythonlings follows
 Semantic Versioning.
+
+## [0.4.2] - 2026-08-17
+
+### Changed
+
+- Refreshed the project branding, screenshots, terminal demo, and contributor
+  guidance.
+
+### Fixed
+
+- `pythonlings update` now prefers the current workspace while preserving the
+  precedence of an explicit `--path` and global `--root`. Missing and invalid
+  targets fail without being created or modified.
+- Invalid, unreadable, and unsafe manifests now produce contextual command-line
+  errors without Python tracebacks.
+- Workspace initialization and updates preserve custom `.gitignore` entries,
+  ordering, line endings, and repeated-run idempotency.
 
 ## [0.4.1] - 2026-06-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ The fastest way in is a [`good first issue`](https://github.com/abhiksark/python
 
 ## Where the work is
 
-- **[0.3.0 roadmap](docs/roadmap/0.3.0.md)** — the current focus (wider adoption
-  for beginners). Each roadmap issue is written to be picked up cold: it has
-  context, scope, the exact files to touch, and how to verify.
-- Browse open issues by label: [`good first issue`](https://github.com/abhiksark/pythonlings/issues?q=is%3Aopen+label%3A%22good+first+issue%22),
+- Track current work in the
+  [open issue tracker](https://github.com/abhiksark/pythonlings/issues?q=is%3Aissue+is%3Aopen).
+- Find contributor-ready work by label: [`good first issue`](https://github.com/abhiksark/pythonlings/issues?q=is%3Aopen+label%3A%22good+first+issue%22),
   [`help wanted`](https://github.com/abhiksark/pythonlings/issues?q=is%3Aopen+label%3A%22help+wanted%22).
 
 ## Claiming an issue

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
+<!-- RELEASE.md -->
 # Release Checklist
 
 Pythonlings follows Semantic Versioning. Use full `MAJOR.MINOR.PATCH` versions in
@@ -27,10 +28,10 @@ pythonlings --root "$tmp" solution variables1
 pythonlings --root "$tmp" reset variables1 --yes
 ```
 
-Expected release version for `v0.3.0`:
+Confirm that the command reports the version represented by the release tag:
 
 ```text
-pythonlings 0.3.0
+pythonlings MAJOR.MINOR.PATCH
 ```
 
 ## Tag And Publish

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ uvx pythonlings
 How it works: **edit** the broken exercise in the built-in editor → checks
 rerun as you type and advance you to the next one. That's the whole loop.
 
-Status: `v0.4.0`, alpha — published on PyPI as `pythonlings`.
+Status: alpha. Published on PyPI as `pythonlings`.
 
 ![Coding screen](docs/assets/screenshots/coding-screen.png)
 
@@ -193,9 +193,10 @@ together. Keep exercise and check filenames mirrored, for example
 
 ## Contributing
 
-Pythonlings is actively developed and welcomes contributors — beginners included.
-The current focus is the [0.3.0 roadmap](docs/roadmap/0.3.0.md) (wider adoption),
-and every roadmap issue is written to be picked up cold. Start with a
+Pythonlings is actively developed and welcomes contributors, including
+beginners. Current work is tracked in the
+[open issue tracker](https://github.com/abhiksark/pythonlings/issues?q=is%3Aissue+is%3Aopen).
+Start with a
 [`good first issue`](https://github.com/abhiksark/pythonlings/issues?q=is%3Aopen+label%3A%22good+first+issue%22),
 comment to claim it, and see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -1,3 +1,4 @@
+<!-- docs-site/faq.md -->
 # FAQ
 
 ## How is this different from Rustlings?
@@ -26,7 +27,7 @@ Yes. All exercises and the bundled local Python reference (press `F5` in the TUI
 
 ## Is Pythonlings on PyPI?
 
-Yes — install it as [`pythonlings`](https://pypi.org/project/pythonlings/) (current release: `v0.4.0`).
+Yes. Install it as [`pythonlings`](https://pypi.org/project/pythonlings/).
 
 ## How do I see the reference answer?
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,4 +1,5 @@
 ---
+# docs-site/index.md
 hide:
   - toc
 ---
@@ -38,5 +39,7 @@ Prefer a permanent install? See [Quick Start](quick-start.md) for `pipx`, `uv to
 
 ## Project status
 
-Pythonlings is `v0.4.0`, published on PyPI as `pythonlings`. The learner loop, CLI, and
-curriculum are stable; see the [Roadmap](roadmap.md) for what's next.
+Pythonlings is published on PyPI as `pythonlings`. The learner loop, CLI, and
+curriculum are stable; see the [Roadmap](roadmap.md) and
+[open issue tracker](https://github.com/abhiksark/pythonlings/issues?q=is%3Aissue+is%3Aopen)
+for current work.

--- a/docs-site/quick-start.md
+++ b/docs-site/quick-start.md
@@ -1,6 +1,7 @@
+<!-- docs-site/quick-start.md -->
 # Quick Start
 
-> Current release: **v0.4.0** · [PyPI](https://pypi.org/project/pythonlings/)
+> Latest release: [pythonlings on PyPI](https://pypi.org/project/pythonlings/)
 
 ## Zero-Install (uvx)
 

--- a/docs-site/roadmap.md
+++ b/docs-site/roadmap.md
@@ -1,7 +1,8 @@
+<!-- docs-site/roadmap.md -->
 # Roadmap
 
-Pythonlings is `v0.4.0`, published on PyPI as `pythonlings`. Install with
-`uvx pythonlings` or `pip install pythonlings`.
+Pythonlings is published on PyPI as `pythonlings`. Install with `uvx
+pythonlings` or `pip install pythonlings`.
 
 ## Shipped
 
@@ -11,13 +12,12 @@ Pythonlings is `v0.4.0`, published on PyPI as `pythonlings`. Install with
 - Bundled Python docs snippets with official docs links.
 - Published on PyPI as `pythonlings`; canonical install is `uvx pythonlings`.
 
-## Next Work
+## Active Work
 
-- Improve first-run onboarding and empty-state copy.
-- Harden keyboard flow around `Enter`, `Esc`, `F4`, and `F5`.
-- Add more TUI tests for the coding screen, docs window, and topic picker.
-- Add a release smoke test that installs the built wheel and exercises the CLI.
-- Continue auditing exercises for clearer hints and stronger hidden checks.
+Current priorities and ready-to-pick-up tasks are maintained in the
+[open issue tracker](https://github.com/abhiksark/pythonlings/issues?q=is%3Aissue+is%3Aopen).
+New contributors can start with the
+[`good first issue` label](https://github.com/abhiksark/pythonlings/issues?q=is%3Aopen+label%3A%22good+first+issue%22).
 
 ## Release Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
+# pyproject.toml
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
 name = "pythonlings"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python learnings, Rustlings-style, in a terminal TUI."
 readme = "Readme.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Prepares `dev` for the immutable v0.4.2 release after the `.gitignore`, manifest-error, and update-precedence fixes landed. Package metadata and dated release notes now agree on 0.4.2, while public status pages use PyPI as the live version source instead of hardcoded stale release numbers.

Release guidance now uses a version-neutral expected-output example. Contributor and roadmap pages route current work to the active issue tracker.

## Tests

- `python -m pytest -q`: 185 passed
- Python 3.9 isolated suite: 185 passed; curriculum and installed-wheel smoke passed
- Python 3.10 isolated suite: 185 passed; curriculum and installed-wheel smoke passed
- `pythonlings --root tests/fixtures/passing_curriculum verify`: `passing1` and `passing2` passed
- `python -m mkdocs build --strict`: passed
- `python -m build`: built `pythonlings-0.4.2.tar.gz` and `pythonlings-0.4.2-py3-none-any.whl`
- Clean 0.4.2 wheel install: version, init, list, solution, and reset flows passed
- Installed wheel patch smokes: `.gitignore` preservation/idempotency, current-workspace update precedence, no-create failures, and friendly invalid-manifest exit status passed
- Code review: complete (`20260817-release-metadata`); no actionable findings remain

## Screenshots

Not applicable. This change updates release metadata and documentation only.

## Checklist

- [x] Updated docs when behavior changed
- [x] Existing regression and installed-wheel tests cover the included behavior
- [x] Verified `python -m pytest -q`

## Post-Deploy Monitoring & Validation

- Logs: watch the GitHub Actions `publish` workflow for `ERROR`, tag/version mismatch, build failure, and trusted-publishing failure messages.
- Surfaces: verify the GitHub Release asset list and the PyPI 0.4.2 Files and provenance views.
- Healthy signals: the annotated `v0.4.2` tag resolves to the `dev` to `main` promotion commit; the workflow succeeds; PyPI exposes one sdist and one wheel with provenance; a clean install reports `pythonlings 0.4.2`.
- Failure trigger: stop if any tag, release, artifact, package version, or ancestry check disagrees. Do not move the tag or overwrite PyPI; publish corrections as v0.4.3.
- Window and owner: the maintainer validates continuously from tag creation through the successful clean-environment install.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
