### PR TITLE
curriculum: add actionable assertion messages to JSON checks (batch 2 of 2)

### DIFF
--- a/checks/json/json7.py
+++ b/checks/json/json7.py
@@ -1,3 +1,3 @@
-assert settings["theme"] == "dark"
-assert encoded == '{"font_size": 12, "theme": "dark"}'
+assert settings["theme"] == "dark", f"Expected settings['theme'] to be 'dark', got {settings.get('theme')!r}"
+assert encoded == '{"font_size": 12, "theme": "dark"}', f"Expected encoded JSON string '{{\"font_size\": 12, \"theme\": \"dark\"}}', got {encoded!r}"
 print("json7 ok")

--- a/checks/json/json8.py
+++ b/checks/json/json8.py
@@ -1,4 +1,4 @@
-assert decoded == original
-assert tag_count == 2
-assert level == 3
+assert decoded == original, f"Expected decoded dict to equal original {original!r}, got {decoded!r}"
+assert tag_count == 2, f"Expected tag_count to be 2, got {tag_count!r}"
+assert level == 3, f"Expected level to be 3, got {level!r}"
 print("json8 ok")


### PR DESCRIPTION
This PR adds actionable, beginner-facing assertion messages to bare assertions in `checks/json/json7.py` and `checks/json/json8.py` (issue #102).

### Summary of Changes
- `checks/json/json7.py`: Added explicit failure messages indicating expected and actual values for `settings["theme"]` and `encoded` JSON string.
- `checks/json/json8.py`: Added explicit failure messages for `decoded`, `tag_count`, and `level` assertions.

All predicates, success outputs, and execution orders remain unchanged.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
