### PR TITLE
curriculum: add actionable assertion message to context_managers8 check

### DIFF
--- a/checks/context_managers/context_managers8.py
+++ b/checks/context_managers/context_managers8.py
@@ -8,7 +8,7 @@ assert r.release_log == ["released"], (
 with ManagedPool(r) as res2:
     pass
 
-assert r.acquired is False
+assert r.acquired is False, "resource should be released after the second with-block"
 assert r.release_log == ["released", "released"], (
     f"release_log should have two entries after two uses, got {r.release_log!r}"
 )


### PR DESCRIPTION
Fixes #92.

Adds a beginner-facing error message to the bare assertion in `checks/context_managers/context_managers8.py`. All assertion predicates, execution steps, and success prints remain unchanged.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
