### PR TITLE
curriculum: add actionable assertion messages to decorators checks (batch 2 of 2)

### DIFF
--- a/checks/decorators/decorators10.py
+++ b/checks/decorators/decorators10.py
@@ -1,12 +1,18 @@
-assert slow_square(4) == 16
-assert slow_square(5) == 25
+assert slow_square(4) == 16, f"slow_square(4) should return 16, got {slow_square(4)}"
+assert slow_square(5) == 25, f"slow_square(5) should return 25, got {slow_square(5)}"
 # Second calls must hit the cache, not recompute
-assert slow_square(4) == 16
-assert slow_square(5) == 25
+assert (
+    slow_square(4) == 16
+), f"cached slow_square(4) call should return 16, got {slow_square(4)}"
+assert (
+    slow_square(5) == 25
+), f"cached slow_square(5) call should return 25, got {slow_square(5)}"
 assert call_count == 2, (
     f"slow_square should have been called exactly 2 times (once per unique arg), "
     f"but call_count is {call_count}"
 )
 assert (4,) in slow_square.cache, "cache should contain key (4,) for arg 4"
-assert slow_square.cache[(4,)] == 16
+assert (
+    slow_square.cache[(4,)] == 16
+), f"slow_square.cache[(4,)] should be 16, got {slow_square.cache[(4,)]}"
 print("decorators10 ✓")


### PR DESCRIPTION
This PR addresses #89 by adding clear, actionable assertion messages to the 5 remaining bare assertions in `checks/decorators/decorators10.py`.

### Changes
- Added descriptive error messages showing expected vs actual return values for `slow_square(4)`, `slow_square(5)`, cached calls, and dictionary lookup in `slow_square.cache[(4,)]`.
- Preserved existing assertion order, logic, and success print output.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
