### PR TITLE
ci: add automated Ruff linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: pip install -e ".[dev]"
-      - run: ruff check .
-      - run: ruff format --check .
+      - name: Check lint with Ruff
+        continue-on-error: true
+        run: ruff check .
+      - name: Check formatting with Ruff
+        continue-on-error: true
+        run: ruff format --check .
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
       - name: Check lint with Ruff
         continue-on-error: true
         run: ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,10 @@ ruff check .
 ruff format --check .
 ```
 
+Ruff currently runs in advisory mode while existing violations are addressed
+incrementally. New and modified Python files should follow its lint and format
+output.
+
 ## Curriculum Changes
 
 Every exercise is five artifacts that must stay in sync:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,16 @@ python -m pytest -q
 
 Supported Python: 3.9+.
 
+### Linting and formatting
+
+Install the development dependencies, then run Ruff before opening a pull
+request:
+
+```bash
+ruff check .
+ruff format --check .
+```
+
 ## Curriculum Changes
 
 Every exercise is five artifacts that must stay in sync:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ Documentation = "https://pythonlings.abhik.ai/"
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
+    "ruff==0.16.4",
 ]
 
 [project.scripts]
@@ -77,3 +78,23 @@ packages = ["pythonlings"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 80
+target-version = "py39"
+include = ["*.py", "*.pyi", "pyproject.toml"]
+extend-exclude = [
+    "exercises",
+    "solutions",
+    "tests/fixtures",
+]
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "E501",
+    "F",
+    "I",
+]


### PR DESCRIPTION
## Summary

Related to #124.

This draft adds the initial Ruff configuration, CI checks, and local usage instructions.

While validating the change, I found that applying Ruff repository-wide exposes a large amount of existing style debt. It also reports expected errors in learner exercises, shared-namespace checks, and intentionally invalid test fixtures. I have intentionally not reformatted the repository or added extensive repository-specific exclusions yet, to keep this PR focused.

## Tests

```bash
zhangyuyang@zhangyuyangdeMacBook-Pro pythonlings % python -m pytest -q
.......................................................................................................................................................................... [ 80%]
..........................................                                                                                                                                 [100%]
212 passed in 40.27s
```

## Screenshots

## Checklist

- [x] Updated docs when behavior changed
- [ ] Added or updated tests
- [x] Verified `python -m pytest -q`
