### PR TITLE
fix(curriculum): add actionable itertools assertion messages

### DIFF
--- a/checks/itertools/itertools3.py
+++ b/checks/itertools/itertools3.py
@@ -1,2 +1,10 @@
-assert coordinates == [(0, "low"), (0, "high"), (1, "low"), (1, "high")]
+assert coordinates == [
+    (0, "low"),
+    (0, "high"),
+    (1, "low"),
+    (1, "high"),
+], (
+    "coordinates should contain every (x, y) pair from xs and ys, "
+    f"got {coordinates!r}"
+)
 print("itertools3 ok")

--- a/checks/itertools/itertools4.py
+++ b/checks/itertools/itertools4.py
@@ -1,2 +1,8 @@
-assert grouped == {"fruit": ["apple", "pear"], "veg": ["carrot"]}
+assert grouped == {
+    "fruit": ["apple", "pear"],
+    "veg": ["carrot"],
+}, (
+    "grouped should map each category to its item names, "
+    f"got {grouped!r}"
+)
 print("itertools4 ok")

--- a/checks/itertools/itertools5.py
+++ b/checks/itertools/itertools5.py
@@ -1,2 +1,5 @@
-assert running_totals == [3, 7, 12, 18]
+assert running_totals == [3, 7, 12, 18], (
+    "running_totals should contain cumulative sums [3, 7, 12, 18], "
+    f"got {running_totals!r}"
+)
 print("itertools5 ok")

--- a/checks/itertools/itertools6.py
+++ b/checks/itertools/itertools6.py
@@ -1,2 +1,5 @@
-assert repeated == ["red", "blue", "red", "blue", "red", "blue"]
+assert repeated == ["red", "blue", "red", "blue", "red", "blue"], (
+    "repeated should cycle through colors for six values, "
+    f"got {repeated!r}"
+)
 print("itertools6 ok")

--- a/checks/itertools/itertools7.py
+++ b/checks/itertools/itertools7.py
@@ -1,2 +1,5 @@
-assert pairs == [("a", 1), ("b", "?"), ("c", "?")]
+assert pairs == [("a", 1), ("b", "?"), ("c", "?")], (
+    "pairs should fill missing right-side values with '?', "
+    f"got {pairs!r}"
+)
 print("itertools7 ok")

--- a/checks/itertools/itertools8.py
+++ b/checks/itertools/itertools8.py
@@ -1,3 +1,9 @@
-assert flattened == [1, 2, 3, 4, 5]
-assert adjacent_pairs == [(1, 2), (2, 3), (3, 4), (4, 5)]
+assert flattened == [1, 2, 3, 4, 5], (
+    "flattened should contain all batch items in order, "
+    f"got {flattened!r}"
+)
+assert adjacent_pairs == [(1, 2), (2, 3), (3, 4), (4, 5)], (
+    "adjacent_pairs should contain each neighboring pair, "
+    f"got {adjacent_pairs!r}"
+)
 print("itertools8 ok")


### PR DESCRIPTION
## Summary

Adds actionable, beginner-facing messages to the seven bare assertions in the itertools checks requested by #100. The assertion predicates, execution order, helper statements, and success output are unchanged; only the six scoped check files are modified.

Closes #100

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `pythonlings --root tests/fixtures/passing_curriculum verify` — passed
- AST audit of the six scoped files — 0 bare assertions remaining
- `python -m pytest -q` — 209 passed, 6 failed locally because Windows symlink creation is unavailable (`WinError 1314`); the failures are in existing symlink-security tests and are unrelated to this change

## Screenshots

Not applicable; this is a curriculum check-message change.

## Checklist

- [x] Documentation update not needed; this change only improves hidden assertion feedback
- [ ] Added or updated tests — not needed; existing solution verification covers the reference answers
- [ ] Verified `python -m pytest -q` — local Windows symlink privilege prevented six existing tests from running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation feedback for iterator-related checks.
  * Assertion failures now describe expected behavior and display the actual values received.
  * Clarified diagnostics for coordinates, grouped data, running totals, repeated values, placeholders, flattened results, and adjacent pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->