### PR TITLE
fix(curriculum): add actionable enum assertion messages

### DIFF
--- a/checks/enums/enums1.py
+++ b/checks/enums/enums1.py
@@ -1,4 +1,10 @@
-assert Color.RED.value == "red"
-assert Color.BLUE.value == "blue"
-assert favorite is Color.RED
+assert Color.RED.value == "red", (
+    f"Color.RED.value should be 'red', got {Color.RED.value!r}"
+)
+assert Color.BLUE.value == "blue", (
+    f"Color.BLUE.value should be 'blue', got {Color.BLUE.value!r}"
+)
+assert favorite is Color.RED, (
+    f"favorite should be Color.RED, got {favorite!r}"
+)
 print("enums1 ok")

--- a/checks/enums/enums2.py
+++ b/checks/enums/enums2.py
@@ -1,3 +1,9 @@
-assert [member.name for member in Status] == ["TODO", "DOING", "DONE"]
-assert [member.value for member in Status] == [1, 2, 3]
+assert [member.name for member in Status] == ["TODO", "DOING", "DONE"], (
+    "Status names should be ['TODO', 'DOING', 'DONE'], got "
+    f"{[member.name for member in Status]!r}"
+)
+assert [member.value for member in Status] == [1, 2, 3], (
+    f"Status values should be [1, 2, 3], got "
+    f"{[member.value for member in Status]!r}"
+)
 print("enums2 ok")

--- a/checks/enums/enums3.py
+++ b/checks/enums/enums3.py
@@ -1,3 +1,7 @@
-assert selected_name == "HIGH"
-assert selected_value == 5
+assert selected_name == "HIGH", (
+    f"selected_name should be 'HIGH', got {selected_name!r}"
+)
+assert selected_value == 5, (
+    f"selected_value should be 5, got {selected_value!r}"
+)
 print("enums3 ok")

--- a/checks/enums/enums4.py
+++ b/checks/enums/enums4.py
@@ -1,2 +1,4 @@
-assert size_codes == ["S", "M", "L"]
+assert size_codes == ["S", "M", "L"], (
+    f"size_codes should be ['S', 'M', 'L'], got {size_codes!r}"
+)
 print("enums4 ok")

--- a/checks/enums/enums5.py
+++ b/checks/enums/enums5.py
@@ -1,4 +1,10 @@
-assert is_terminal(TicketState.OPEN) is False
-assert is_terminal(TicketState.CLOSED) is True
-assert is_terminal(TicketState.CANCELLED) is True
+assert is_terminal(TicketState.OPEN) is False, (
+    "is_terminal(TicketState.OPEN) should be False"
+)
+assert is_terminal(TicketState.CLOSED) is True, (
+    "is_terminal(TicketState.CLOSED) should be True"
+)
+assert is_terminal(TicketState.CANCELLED) is True, (
+    "is_terminal(TicketState.CANCELLED) should be True"
+)
 print("enums5 ok")

--- a/checks/enums/enums6.py
+++ b/checks/enums/enums6.py
@@ -1,3 +1,7 @@
-assert Direction.NORTH.delta() == (0, -1)
-assert Direction.EAST.delta() == (1, 0)
+assert Direction.NORTH.delta() == (0, -1), (
+    "Direction.NORTH.delta() should return (0, -1)"
+)
+assert Direction.EAST.delta() == (1, 0), (
+    "Direction.EAST.delta() should return (1, 0)"
+)
 print("enums6 ok")


### PR DESCRIPTION
## Summary

Closes #105.

Add actionable assertion messages to the existing enum curriculum checks in checks/enums/enums1.py through checks/enums/enums6.py.

The predicates, check order, side effects, and success output are unchanged.

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (passing1, passing2)
- `python -m pytest -q` — 208 passed, 7 failed in this Windows environment:
  - 6 failures cannot create symlinks (WinError 1314)
  - 1 failure resolves an older installed pythonlings package without pythonlings.__main__
- `git diff --check` — passed

## Screenshots

Not applicable.

## Checklist

- [ ] Updated docs when behavior changed — not applicable; assertion messages only
- [ ] Added or updated tests — not applicable; issue scope is assertion messages
- [ ] Verified `python -m pytest -q` — run; environment-only failures are documented above