### PR TITLE
fix(curriculum): add actionable pathlib assertion messages

### DIFF
--- a/checks/pathlib/pathlib1.py
+++ b/checks/pathlib/pathlib1.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
-assert path == Path("notes/today.txt")
-assert filename == "today.txt"
+assert path == Path("notes/today.txt"), (
+    f"path should be Path('notes/today.txt'), got {path!r}"
+)
+assert filename == "today.txt", (
+    f"filename should be 'today.txt', got {filename!r}"
+)
 print("pathlib1 ok")

--- a/checks/pathlib/pathlib2.py
+++ b/checks/pathlib/pathlib2.py
@@ -1,4 +1,6 @@
 from pathlib import Path
 
-assert source == Path("pythonlings/src/main.py")
+assert source == Path("pythonlings/src/main.py"), (
+    f"source should be Path('pythonlings/src/main.py'), got {source!r}"
+)
 print("pathlib2 ok")

--- a/checks/pathlib/pathlib3.py
+++ b/checks/pathlib/pathlib3.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-assert parent == Path("docs")
-assert stem == "guide"
-assert suffix == ".md"
+assert parent == Path("docs"), (
+    f"parent should be Path('docs'), got {parent!r}"
+)
+assert stem == "guide", f"stem should be 'guide', got {stem!r}"
+assert suffix == ".md", f"suffix should be '.md', got {suffix!r}"
 print("pathlib3 ok")

--- a/checks/pathlib/pathlib4.py
+++ b/checks/pathlib/pathlib4.py
@@ -1,4 +1,7 @@
 from pathlib import Path
 
-assert python_files == [Path("app.py"), Path("tests.py")]
+assert python_files == [Path("app.py"), Path("tests.py")], (
+    f"python_files should be [Path('app.py'), Path('tests.py')], "
+    f"got {python_files!r}"
+)
 print("pathlib4 ok")

--- a/checks/pathlib/pathlib5.py
+++ b/checks/pathlib/pathlib5.py
@@ -1,4 +1,6 @@
 from pathlib import Path
 
-assert final == Path("reports/final.txt")
+assert final == Path("reports/final.txt"), (
+    f"final should be Path('reports/final.txt'), got {final!r}"
+)
 print("pathlib5 ok")

--- a/checks/pathlib/pathlib6.py
+++ b/checks/pathlib/pathlib6.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
-assert processed == Path("data/raw.json")
-assert parts[-2:] == ("data", "raw.json")
+assert processed == Path("data/raw.json"), (
+    f"processed should be Path('data/raw.json'), got {processed!r}"
+)
+assert parts[-2:] == ("data", "raw.json"), (
+    f"parts[-2:] should be ('data', 'raw.json'), got {parts[-2:]!r}"
+)
 print("pathlib6 ok")


### PR DESCRIPTION
## Summary

Closes #106.

Add actionable assertion messages to the existing pathlib curriculum checks in checks/pathlib/pathlib1.py through checks/pathlib/pathlib6.py.

The predicates, check order, side effects, and success output are unchanged.

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (passing1, passing2)
- `python -m compileall -q checks/pathlib` — passed
- `python -m pytest -q` — 208 passed, 7 failed in this Windows environment:
  - 6 failures cannot create symlinks (WinError 1314)
  - 1 failure resolves an older installed pythonlings package without pythonlings.__main__
- `git diff --check` — passed

## Screenshots

Not applicable.

## Checklist

- [ ] Updated docs when behavior changed — not applicable; assertion messages only
- [ ] Added or updated tests — not applicable; issue scope is assertion messages
- [ ] Verified `python -m pytest -q` — run; environment-only failures are documented above