### PR TITLE
docs: clarify automatic checks in built-in editor

### DIFF
--- a/docs-site/how-it-works.md
+++ b/docs-site/how-it-works.md
@@ -9,8 +9,8 @@ Pythonlings follows a tight edit-check-advance loop. Here is what happens at eac
 ## The Learner Loop
 
 1. **Open the next pending exercise** — the TUI shows the first incomplete exercise in the curriculum.
-2. **Edit the broken code** — fix the intentional mistake directly in the built-in editor (or any external editor you prefer).
-3. **Checks rerun automatically** — roughly 0.6 s after you stop typing, Pythonlings re-evaluates the exercise in a fresh subprocess. There is no filesystem watcher; the debounce fires inside the TUI editor.
+2. **Edit the broken code** — fix the intentional mistake directly in the built-in editor. This is the automatic edit-check-advance workflow. If you use an external editor, save the file and run `pythonlings run <name>` to check it manually.
+3. **Checks rerun automatically** — roughly 0.6 s after you stop typing in the built-in editor, Pythonlings re-evaluates the exercise in a fresh subprocess. There is no filesystem watcher, so external saves do not trigger this automatic check.
 4. **Remove the `# I AM NOT DONE` marker** — the marker is your explicit "I'm finished" signal. Passing checks alone does not advance the exercise (see below).
 5. **Advance** — once checks are green *and* the marker is gone, the exercise is marked complete and the TUI moves to the next one.
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -7,8 +7,9 @@ hide:
 <div class="pl-hero" markdown>
   <div class="pl-eyebrow">Rustlings for Python</div>
   <div class="pl-title">Learn Python by fixing tiny broken programs.</div>
-  <div class="pl-subtitle">292 exercises across 31 topics. Hidden checks rerun the
-    instant you save — fix the code, watch it go green, advance.</div>
+  <div class="pl-subtitle">292 exercises across 31 topics. In the built-in editor,
+    hidden checks rerun after you stop typing — fix the code, watch it go green,
+    advance.</div>
   <div class="pl-install">$ uvx pythonlings init</div>
   <div class="pl-ctas">
     <a class="pl-btn" href="quick-start/">Get started →</a>

--- a/docs-site/quick-start.md
+++ b/docs-site/quick-start.md
@@ -61,6 +61,8 @@ pythonlings update               # pull new exercises into an existing workspace
 ## Exercise Loop
 
 Each exercise contains a `# I AM NOT DONE` marker. Open the file in the TUI
-editor (or any editor), fix the broken code, then remove the marker. Pythonlings
-runs the hidden check automatically; when the check passes and the marker is gone,
-the exercise is marked complete and progress advances to the next one.
+editor and fix the broken code, then remove the marker. The built-in editor runs
+the hidden check automatically; if you use an external editor, save the file and
+run `pythonlings run <name>` to check it manually. When the check passes and the
+marker is gone in the TUI, the exercise is marked complete and progress advances
+to the next one.


### PR DESCRIPTION
## Summary

Closes #78.

Clarify that the automatic edit-check-advance loop is provided by the built-in editor.

Document that external editors require saving the exercise and running pythonlings run <name> manually. Update the how-it-works, quick-start, and homepage documentation to keep the workflow description consistent.

## Tests

- `mkdocs build --strict` — passed
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (passing1, passing2)
- `python -m pytest -q` — 208 passed, 7 failed in this Windows environment:
  - 6 failures cannot create symlinks (WinError 1314)
  - 1 failure resolves an older installed pythonlings package without pythonlings.__main__
- `git diff --check` — passed

The strict documentation build also reports only existing warnings: the future MkDocs 2.0 compatibility warning and docs-site/AGENTS.md being outside the navigation.

## Screenshots

Not applicable; documentation wording only.

## Checklist

- [x] Updated docs when behavior changed
- [ ] Added or updated tests — documentation-only change
- [ ] Verified `python -m pytest -q` — run; environment-only failures are documented above