### PR TITLE
fix(curriculum): add actionable advanced OOP assertion messages

### DIFF
--- a/checks/oop_advanced/oop_advanced1.py
+++ b/checks/oop_advanced/oop_advanced1.py
@@ -1,4 +1,4 @@
 dog = Dog()
-assert isinstance(dog, Animal)
-assert dog.speak() == "sound"
+assert isinstance(dog, Animal), "dog should be an instance of Animal"
+assert dog.speak() == "sound", "dog.speak() should return 'sound'"
 print("oop_advanced1 ok")

--- a/checks/oop_advanced/oop_advanced2.py
+++ b/checks/oop_advanced/oop_advanced2.py
@@ -1,4 +1,8 @@
 employee = Employee("Ada", "Engineer")
-assert employee.name == "Ada"
-assert employee.role == "Engineer"
+assert employee.name == "Ada", (
+    f"employee.name should be 'Ada', got {employee.name!r}"
+)
+assert employee.role == "Engineer", (
+    f"employee.role should be 'Engineer', got {employee.role!r}"
+)
 print("oop_advanced2 ok")

--- a/checks/oop_advanced/oop_advanced3.py
+++ b/checks/oop_advanced/oop_advanced3.py
@@ -1,3 +1,3 @@
 shapes = [Square(3), Rectangle(2, 5)]
-assert total_area(shapes) == 19
+assert total_area(shapes) == 19, "total_area(shapes) should be 19"
 print("oop_advanced3 ok")

--- a/checks/oop_advanced/oop_advanced4.py
+++ b/checks/oop_advanced/oop_advanced4.py
@@ -1,3 +1,3 @@
 user = User("Lin")
-assert user.name == "Lin"
+assert user.name == "Lin", f"user.name should be 'Lin', got {user.name!r}"
 print("oop_advanced4 ok")

--- a/checks/oop_advanced/oop_advanced5.py
+++ b/checks/oop_advanced/oop_advanced5.py
@@ -1,3 +1,3 @@
 playlist = Playlist(["one", "two", "three"])
-assert len(playlist) == 3
+assert len(playlist) == 3, "len(playlist) should be 3"
 print("oop_advanced5 ok")

--- a/checks/oop_advanced/oop_advanced6.py
+++ b/checks/oop_advanced/oop_advanced6.py
@@ -1,2 +1,4 @@
-assert repr(Point(2, 5)) == "Point(x=2, y=5)"
+assert repr(Point(2, 5)) == "Point(x=2, y=5)", (
+    "Point(2, 5) should be represented as 'Point(x=2, y=5)'"
+)
 print("oop_advanced6 ok")


### PR DESCRIPTION
## Summary

- Add actionable, beginner-facing assertion messages to the eight bare checks in `checks/oop_advanced/oop_advanced1.py` through `oop_advanced6.py`.
- Preserve every assertion predicate, execution order, helper statement, and success output.
- Keep the change limited to the six files listed in #107; no learner exercises, reference solutions, hints, documentation, or curriculum metadata changed.

Closes #107

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `python -m pytest -q` — 209 passed, 6 failed
  - The six failures are Windows symlink-permission tests (`WinError 1314`) in doctor/manifest coverage; they are unrelated to this change.
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (`passing1`, `passing2`)
- AST audit of the six listed files — 0 bare assertions remaining

## Screenshots

Not applicable; this is a curriculum check-message change with no TUI changes.

## Checklist

- [ ] Updated docs when behavior changed — not applicable; #107 explicitly limits this change to assertion messages.
- [ ] Added or updated tests — not applicable; existing verification tests cover the unchanged predicates.
- [x] Verified `python -m pytest -q` — completed; 209 passed and 6 unrelated Windows symlink-permission tests failed with `WinError 1314`.