### PR TITLE
fix(curriculum): add actionable JSON assertion messages

### DIFF
--- a/checks/json/json1.py
+++ b/checks/json/json1.py
@@ -1,3 +1,5 @@
-assert data == {"name": "Ada", "language": "Python"}
-assert name == "Ada"
+assert data == {"name": "Ada", "language": "Python"}, (
+    f"data should contain Ada and Python, got {data!r}"
+)
+assert name == "Ada", f"name should be 'Ada', got {name!r}"
 print("json1 ok")

--- a/checks/json/json2.py
+++ b/checks/json/json2.py
@@ -1,2 +1,4 @@
-assert text == '{"a": 1, "b": 2}'
+assert text == '{"a": 1, "b": 2}', (
+    "text should be '{\"a\": 1, \"b\": 2}'"
+)
 print("json2 ok")

--- a/checks/json/json3.py
+++ b/checks/json/json3.py
@@ -1,2 +1,2 @@
-assert city == "London"
+assert city == "London", f"city should be 'London', got {city!r}"
 print("json3 ok")

--- a/checks/json/json4.py
+++ b/checks/json/json4.py
@@ -1,2 +1,4 @@
-assert restored == {"ok": True, "count": 3}
+assert restored == {"ok": True, "count": 3}, (
+    f"restored should contain ok=True and count=3, got {restored!r}"
+)
 print("json4 ok")

--- a/checks/json/json5.py
+++ b/checks/json/json5.py
@@ -1,2 +1,2 @@
-assert timezone == "UTC"
+assert timezone == "UTC", f"timezone should be 'UTC', got {timezone!r}"
 print("json5 ok")

--- a/checks/json/json6.py
+++ b/checks/json/json6.py
@@ -1,2 +1,4 @@
-assert active_names == ["Ada", "Guido"]
+assert active_names == ["Ada", "Guido"], (
+    f"active_names should be ['Ada', 'Guido'], got {active_names!r}"
+)
 print("json6 ok")


### PR DESCRIPTION
## Summary

- Add actionable, beginner-facing assertion messages to the seven bare checks in `checks/json/json1.py` through `json6.py`.
- Preserve every assertion predicate, execution order, helper statement, and success output.
- Keep the change limited to the six files listed in #101; no learner exercises, reference solutions, hints, documentation, or curriculum metadata changed.

Closes #101

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `python -m pytest -q` — 209 passed, 6 failed
  - The six failures are Windows symlink-permission tests (`WinError 1314`) in doctor/manifest coverage; they are unrelated to this change.
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (`passing1`, `passing2`)
- AST audit of the six listed files — 0 bare assertions remaining

## Screenshots

Not applicable; this is a curriculum check-message change with no TUI changes.

## Checklist

- [ ] Updated docs when behavior changed — not applicable; #101 explicitly limits this change to assertion messages.
- [ ] Added or updated tests — not applicable; existing verification tests cover the unchanged predicates.
- [x] Verified `python -m pytest -q` — completed; 209 passed and 6 unrelated Windows symlink-permission tests failed with `WinError 1314`.