### PR TITLE
fix(curriculum): add actionable advanced OOP assertion messages

### DIFF
--- a/checks/oop_advanced/oop_advanced10.py
+++ b/checks/oop_advanced/oop_advanced10.py
@@ -1,3 +1,3 @@
-assert issubclass(Square, Shape)
-assert Square(4).area() == 16
+assert issubclass(Square, Shape), "Square should be a subclass of Shape"
+assert Square(4).area() == 16, "Square(4).area() should be 16"
 print("oop_advanced10 ok")

--- a/checks/oop_advanced/oop_advanced11.py
+++ b/checks/oop_advanced/oop_advanced11.py
@@ -1,3 +1,5 @@
 product = Product("book", 12)
-assert product.to_dict() == {"name": "book", "price": 12}
+assert product.to_dict() == {"name": "book", "price": 12}, (
+    "product.to_dict() should return {'name': 'book', 'price': 12}"
+)
 print("oop_advanced11 ok")

--- a/checks/oop_advanced/oop_advanced12.py
+++ b/checks/oop_advanced/oop_advanced12.py
@@ -1,4 +1,6 @@
 result = Vector(1, 2) + Vector(3, 4)
-assert isinstance(result, Vector)
-assert (result.x, result.y) == (4, 6)
+assert isinstance(result, Vector), "result should be a Vector"
+assert (result.x, result.y) == (4, 6), (
+    f"result coordinates should be (4, 6), got {(result.x, result.y)!r}"
+)
 print("oop_advanced12 ok")

--- a/checks/oop_advanced/oop_advanced7.py
+++ b/checks/oop_advanced/oop_advanced7.py
@@ -1,3 +1,7 @@
-assert Book("A", "123") == Book("B", "123")
-assert Book("A", "123") != Book("C", "999")
+assert Book("A", "123") == Book("B", "123"), (
+    "books with the same ISBN should compare equal"
+)
+assert Book("A", "123") != Book("C", "999"), (
+    "books with different ISBNs should not compare equal"
+)
 print("oop_advanced7 ok")

--- a/checks/oop_advanced/oop_advanced8.py
+++ b/checks/oop_advanced/oop_advanced8.py
@@ -1,3 +1,5 @@
 coord = Coordinate.from_text("3,4")
-assert (coord.x, coord.y) == (3, 4)
+assert (coord.x, coord.y) == (3, 4), (
+    f"coord should be (3, 4), got {(coord.x, coord.y)!r}"
+)
 print("oop_advanced8 ok")

--- a/checks/oop_advanced/oop_advanced9.py
+++ b/checks/oop_advanced/oop_advanced9.py
@@ -1,4 +1,4 @@
-assert Grade.is_valid(0) is True
-assert Grade.is_valid(100) is True
-assert Grade.is_valid(101) is False
+assert Grade.is_valid(0) is True, "Grade.is_valid(0) should be True"
+assert Grade.is_valid(100) is True, "Grade.is_valid(100) should be True"
+assert Grade.is_valid(101) is False, "Grade.is_valid(101) should be False"
 print("oop_advanced9 ok")


### PR DESCRIPTION
## Summary

- Add actionable, beginner-facing assertion messages to the eleven bare checks in `checks/oop_advanced/oop_advanced7.py` through `oop_advanced12.py`.
- Preserve every assertion predicate, execution order, helper statement, and success output.
- Keep the change limited to the six files listed in #108; no learner exercises, reference solutions, hints, documentation, or curriculum metadata changed.

Closes #108

## Tests

- `python -m pytest tests/integration/test_solution_verify.py -q` — 1 passed
- `python -m pytest -q` — 209 passed, 6 failed
  - The six failures are Windows symlink-permission tests (`WinError 1314`) in doctor/manifest coverage; they are unrelated to this change.
- `python -m pythonlings --root tests/fixtures/passing_curriculum verify` — passed (`passing1`, `passing2`)
- AST audit of the six listed files — 0 bare assertions remaining

## Screenshots

Not applicable; this is a curriculum check-message change with no TUI changes.

## Checklist

- [ ] Updated docs when behavior changed — not applicable; #108 explicitly limits this change to assertion messages.
- [ ] Added or updated tests — not applicable; existing verification tests cover the unchanged predicates.
- [x] Verified `python -m pytest -q` — completed; 209 passed and 6 unrelated Windows symlink-permission tests failed with `WinError 1314`.